### PR TITLE
Clarify text on alert generation in commissioning

### DIFF
--- a/commissioning.tex
+++ b/commissioning.tex
@@ -49,5 +49,5 @@ Rubin will aim to provide a ``near-live'' alert stream to the Brokers by the end
 
 \subsection{Data Previews based on commissioning data}
 
-Data acquired during commissioning is expected to be of science-quality and will be released to the Rubin data rights community via two Data Previews, Data Preview 1 (DP1) for data from the commissioning camera (ComCam) and Data Preview 2 (DP2) for data from the LSST science camera (LSSTCam) and all previous commissioning data.
+Data acquired during commissioning that is of science-quality will be released to the Rubin data rights community via two Data Previews, Data Preview 1 (DP1) for data from the commissioning camera (ComCam) and Data Preview 2 (DP2) for data from the LSST science camera (LSSTCam) and all previous commissioning data.
 Data Previews will be produced using the DRP pipeline and will include data products for both static sky science and time domain science.

--- a/commissioning.tex
+++ b/commissioning.tex
@@ -43,7 +43,7 @@ The ComCam alerts will be {\it canned}, and released to the community as part of
 Broker teams will be given access to these alerts prior to the DP1 release, but only for development purposes.
 The goal for these ComCam canned alerts is to enable alert brokers and science users to understand their characteristics and to help to validate their quality, rather than to enable rapid followup and \es per se.
 
-Templates, alerts, and other prompt products will also be produced during LSST Cam on-sky commissioning, with the Alert and Prompt Product databases filled and made available for query prior to the DP2 data release (analgous to LSST survey operation, Table~\ref{tab:dp-two-products}). 
+Templates, alerts, and other prompt data products will also be produced during LSST Cam on-sky commissioning, with the Alert and Prompt Product databases filled and made available for query prior to the DP2 data release (analgous to LSST survey operation, Table~\ref{tab:dp-two-products}). 
 Rubin will aim to provide a ``near-live'' alert stream to the Brokers by the end of the LSST Cam SV surveys.
 
 

--- a/commissioning.tex
+++ b/commissioning.tex
@@ -33,14 +33,21 @@ These criteria result in a minimum of three images being needed to construct a t
 The commissioning period provides an excellent opportunity to investigate how many visits in a given band are sufficient to construct a usable template.
 Given the desire to maximize the science harvest prior to the \drone,  relaxing these criteria is an option to be explored.
 
+
 \subsection{Alert generation during commissioning}
 
 Due to the need to verify the instrument characteristics, template quality, and image differencing and Real/Bogus performance, real-time alerts will not be immediately available during the commissioning period.
-Where the accumulated ComCam data is sufficient for alert generation, we expect to provide alerts only after a delay expected to be weeks to months. 
-The goal for these {\it canned} alerts is to enable alert brokers and science users to understand their characteristics and to help to validate their quality rather than to enable rapid followup and \es per se.
-Templates generated during commissioning will be used for Alert Production, with the goal of delivering real-time alert distribution to community brokers by the time of the \svs at the end of LSSTCam commissioning.
+However, the incremental template generation and alert production processes will be tested and optimized during ComCam and LSST Cam on-sky commissioning, resulting in a set of prompt products and alerts.
+
+The ComCam alerts will be {\it canned}, and released to the community as part of DP1 (Table~\ref{tab:dp-one-products}).
+Broker teams will be given access to these alerts prior to the DP1 release, but only for development purposes.
+The goal for these ComCam canned alerts is to enable alert brokers and science users to understand their characteristics and to help to validate their quality, rather than to enable rapid followup and \es per se.
+
+Templates, alerts, and other prompt products will also be produced during LSST Cam on-sky commissioning, with the Alert and Prompt Product databases filled and made available for query prior to the DP2 data release (analgous to LSST survey operation, Table~\ref{tab:dp-two-products}). 
+Rubin will aim to provide a ``near-live'' alert stream to the Brokers by the end of the LSST Cam SV surveys.
+
 
 \subsection{Data Previews based on commissioning data}
 
-Data acquired during the \svs is expected to be of science-quality and will be released to the Rubin data rights community via two Data Previews, Data Preview 1 (DP1) for data from the commissioning camera (ComCam) and Data Preview 2 (DP2) for data from the LSST science camera (LSSTCam) and all previous commissioning data.
+Data acquired during commissioning is expected to be of science-quality and will be released to the Rubin data rights community via two Data Previews, Data Preview 1 (DP1) for data from the commissioning camera (ComCam) and Data Preview 2 (DP2) for data from the LSST science camera (LSSTCam) and all previous commissioning data.
 Data Previews will be produced using the DRP pipeline and will include data products for both static sky science and time domain science.

--- a/commissioning.tex
+++ b/commissioning.tex
@@ -37,7 +37,7 @@ Given the desire to maximize the science harvest prior to the \drone,  relaxing 
 \subsection{Alert generation during commissioning}
 
 Due to the need to verify the instrument characteristics, template quality, and image differencing and Real/Bogus performance, real-time alerts will not be immediately available during the commissioning period.
-However, the incremental template generation and alert production processes will be tested and optimized during ComCam and LSST Cam on-sky commissioning, resulting in a set of prompt products and alerts.
+However, the incremental template generation and alert production processes will be tested and optimized during ComCam and LSST Cam on-sky commissioning, resulting in a set of prompt data products, including alerts.
 
 The ComCam alerts will be {\it canned}, and released to the community as part of DP1 (Table~\ref{tab:dp-one-products}).
 Broker teams will be given access to these alerts prior to the DP1 release, but only for development purposes.


### PR DESCRIPTION
At the Early Science drop-in session, we had a question about how alerts would be generated during commissioning. We say in the RTN-011 tables that ComCam alerts will be generated, canned, and released as part of DP1, and that LSST Cam SV alerts will be generated, and made available via the Alert DB as in survey operations. We also say that we aim to be producing a "near-live" stream by the end of SV.

This PR adds text to section 6.3 to clarify how these alerts will be generated, and to make the text consistent with the tables.

I think (and write!) that the only way we will be able to make  alerts during commissioning is as a by-product of testing and optimizing the incremental template generation process. (There will be no reference images at all for ComCam, and the ComCam coadds will be in a different part of the sky to the LSST Cam visit images - so the templates will have to be made using the first few images taken by each camera, which is what the incremental template generation pipeline does.)

Looking for a review from @leannep and @ebellm to check that I have everything right!